### PR TITLE
Replace galaxy api in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ If REDIS is not running check out its [documentation](https://redis.io/docs/gett
 - Clone the Repo to your machine
 
 ```
-git clone https://github.com/hotosm/galaxy-api.git
+git clone https://github.com/hotosm/export-tool-api.git
 ```
 
 Navigate to repo
 
 ```
-cd galaxy-api
+cd export-tool-api
 ```
 
 - Install python dependencies

--- a/docs/GETTING_STARTED_WITH_DOCKER.md
+++ b/docs/GETTING_STARTED_WITH_DOCKER.md
@@ -63,7 +63,7 @@ http://127.0.0.1:8000/latest/docs
 
 API docs will be displayed like this upon successfull server startup
 
-![image](https://user-images.githubusercontent.com/36752999/191813795-fdfd46fe-5e6c-4ecf-be9b-f9f351d3d1d7.png)
+![image](https://user-images.githubusercontent.com/13560473/204081940-e680a0d3-dcb4-43ff-ad09-5886671ffaff.png)
 
 - Flower dashboard
 


### PR DESCRIPTION
- Fix the README to run with this new repository
- Also update an image in the docker documentation

@kshitijrajsharma to go further, you can update https://github.com/hotosm/export-tool-api/blob/develop/docs/CONFIG_DOC.md and maybe rename the `galaxy` directory.