### PR TITLE
Second draft for raw-data API infrastructure

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -124,7 +124,7 @@ resource "azurerm_linux_virtual_machine" "raw-data-backend" {
   }
 
   admin_ssh_key {
-    public_key = file("~/.ssh/id_rsa.pub")
+    public_key = var.ssh_public_key
     username   = lookup(var.admin_usernames, "backend")
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "raw-data" {
 }
 
 resource "azurerm_virtual_network" "raw-data" {
-  name                = "raw-data-${var.deployment_environment}"
+  name                = join("-", [var.project_name, var.deployment_environment])
   resource_group_name = azurerm_resource_group.raw-data.name
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.raw-data.location
@@ -16,7 +16,7 @@ resource "azurerm_virtual_network" "raw-data" {
 }
 
 resource "azurerm_subnet" "raw-data" {
-  name                 = "raw-data-${var.deployment_environment}"
+  name                 = join("-", [var.project_name, var.deployment_environment])
   resource_group_name  = azurerm_resource_group.raw-data.name
   virtual_network_name = azurerm_virtual_network.raw-data.name
   address_prefixes     = [cidrsubnet(azurerm_virtual_network.raw-data.address_space[0], 8, 0)]
@@ -28,7 +28,7 @@ resource "random_string" "raw_data_db_password" {
 }
 
 resource "azurerm_key_vault" "raw-data" {
-  name                = "raw-data-${var.deployment_environment}"
+  name                = join("-", [var.project_name, var.deployment_environment])
   location            = azurerm_resource_group.raw-data.location
   resource_group_name = azurerm_resource_group.raw-data.name
   sku_name            = "standard"
@@ -80,7 +80,7 @@ resource "azurerm_key_vault" "raw-data" {
 }
 
 resource "azurerm_network_interface" "raw-data-backend" {
-  name                = "raw-data-${var.deployment_environment}"
+  name                = join("-", [var.project_name, var.deployment_environment])
   location            = azurerm_resource_group.raw-data.location
   resource_group_name = azurerm_resource_group.raw-data.name
 
@@ -94,7 +94,7 @@ resource "azurerm_network_interface" "raw-data-backend" {
 resource "azurerm_linux_virtual_machine" "raw-data-backend" {
   admin_username        = lookup(var.admin_usernames, "backend")
   location              = var.arm_location
-  name                  = "raw_data_backend-${var.deployment_environment}"
+  name                  = join("-", [var.project_name, "backend", var.deployment_environment])
   network_interface_ids = [azurerm_network_interface.raw-data-backend.id]
   resource_group_name   = azurerm_resource_group.raw-data.name
   size                  = lookup(var.server_skus, "backend")
@@ -119,7 +119,7 @@ resource "azurerm_linux_virtual_machine" "raw-data-backend" {
     caching              = "None"
     storage_account_type = "StandardSSD_LRS" // StandardSSD_ZRS
     disk_size_gb         = lookup(var.disk_size, "backend_os")
-    name                 = "raw-data-${var.deployment_environment}"
+    name                 = join("-", [var.project_name, var.deployment_environment])
 
   }
 
@@ -130,7 +130,7 @@ resource "azurerm_linux_virtual_machine" "raw-data-backend" {
 }
 
 resource "azurerm_postgresql_flexible_server" "raw-data" {
-  name                = "raw-data-${var.deployment_environment}"
+  name                = join("-", [var.project_name, var.deployment_environment])
   resource_group_name = azurerm_resource_group.raw-data.name
   location            = azurerm_resource_group.raw-data.location
   sku_name            = lookup(var.server_skus, "database")

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -124,7 +124,7 @@ resource "azurerm_linux_virtual_machine" "raw-data-backend" {
   }
 
   admin_ssh_key {
-    public_key = public_key = file("~/.ssh/id_rsa.pub")
+    public_key = file("~/.ssh/id_rsa.pub")
     username   = lookup(var.admin_usernames, "backend")
   }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -55,3 +55,9 @@ variable "server_skus" {
     backend  = "Standard_F2"
   }
 }
+
+variable "ssh_public_key" {
+  type        = string
+  default     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDDqvEc1ESPkG7z2lBX2xYg1fsjXq+JNlcFJdEYtP2SKaVg8Vt0q4/oPBZSHN4p74oHZLEAF//2uFFbqADSvZYRtXIAdp78KvKGXo0Gkqd1pyf0ZPk4kEsfQfxcGeNYmT2T5I1ciYEdpbNgMv9C+WMdXZg0qZhOrgoAeJ6cudsBMtrJu3TTf6At3VELWqB0wL8fMHAfhDxy2+nojitp2OC20y9vAzwg8Uwpv+hVtjf19pijWT5i3gZspNYh+QxsZm+iPzhsD0E40Yi5UH/sqHmulbRYdlbemybeV4XoPEzcZ9UZHTQNXE3yvM592k7AxKHKdhr0y8qL+YzuO3Q0OCmxLtK9iQSchtBvnjhWqQQFfQoVxe+W/Yz0woKzy6+tixZOaTuTio2c23SQrAozTCIEpUkmDpv38FJXDAPl0Emsd5cUWyI2kcyq642B2jKZaKIZgJ0DBlbo7n1TIFYoBRYSa+wDQJ6VkMhNWVOhOBZ6ugu2wOFUe9BU2Q8Fd68hCSc="
+  description = "Content of SSH Key public component"
+}


### PR DESCRIPTION
- Add the content of public component of SSH key instead of referring to the file - since we cannot upload the SSH key file to Terraform Cloud which executes `terraform plan && terraform apply` 
- Azure resources names can't have underscores. Switch to hyphens.
- Format the names better using `join` function rather than string interpolation.